### PR TITLE
Use JSON Schema in development at KIM as default

### DIFF
--- a/src/components/SkohubEditor.js
+++ b/src/components/SkohubEditor.js
@@ -11,7 +11,7 @@ import Preview from './Preview'
 import '../styles/components/FormsStructure.pcss'
 import '../styles/formStyle.pcss'
 
-const DEFAULT_SCHEMA = 'https://raw.githubusercontent.com/literarymachine/oer-metadata-schemas/generic-OER/oer.json'
+const DEFAULT_SCHEMA = 'https://dini-ag-kim.github.io/lrmi-profile/draft/schemas/schema.json'
 
 class SkohubEditor extends React.Component {
   constructor (props) {


### PR DESCRIPTION
It makes sense anyways, especially for writing the blog post and making the screenshots for the extension I'd like to use this schema. I think that it is relatively stable by now for the start...